### PR TITLE
dependabotが同時に作成できるPRの数を10に設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       time: "00:00"
     reviewers:
       - "kelvin27315"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -19,3 +20,4 @@ updates:
       time: "00:00"
     reviewers:
       - "kelvin27315"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
[`open-pull-requests-limit`](
https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit)は内部的に最大10までの制限があるのでその制限と同じ値を設定。

> デフォルトでは、Dependabot は、バージョン更新に対して最大 5 つのプルリクエストをオープンします。 Dependabot からの未解決の pull request が 5 つあると、Dependabot は、未解決の要求の一部がマージまたは閉じられるまで、新しい要求を開けません。 この制限を変更するには open-pull-requests-limit を使います。 これは、パッケージマネージャーのバージョン更新を一時的に無効にする簡単な方法としても使用できます。

と書いてあるけど、多分パッケージマネージャごとに未解決のPRを数えている気がしないでもない。また、閉じたら勝手に開いてくれるというわけじゃなさそうで、次回実行時まで放置される感じがしている
