### PR TITLE
開発依存じゃないものを自動マージするのはpatchバージョンの時のみにする

### DIFF
--- a/.github/workflows/automate-dependabot.yml
+++ b/.github/workflows/automate-dependabot.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot Pull Requests
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.dependency-type == 'direct:development'
         run: |
           gh pr review --approve "$PR_URL"


### PR DESCRIPTION
mainorバージョンアップデートの時とpatchバージョンアップデートの時に自動マージされると思っていたら
mainorバージョンアップデートの時のみ自動マージされてpatchバージョンアップデートの時は自動マージされないのに気づいた。（よく考えれば当たり前）

ただ、アップデートされるパッケージの数と頻度が少ないのでminorバージョンも手動でチェックして良さそうなのでそうすることにした。